### PR TITLE
use equal lengths mode in chordmixer

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -3,7 +3,7 @@ paths:
 speech_commands:
     chordmixer:
       backbone:
-        var_len: True
+        var_len: False
         input_size: 256
         output_size: 3
         max_seq_len: 16000
@@ -12,16 +12,16 @@ speech_commands:
         track_size: 12
         mlp_dropout: 0.1
         layer_dropout: 0
-        prenorm: None
-        norm: None
+        prenorm: BN
+        norm: BN
         decoder: 'linear'
       training:
-        n_epochs: 20
-        batch_size: 2
-        lr: 0.0001
+        n_epochs: 40
+        batch_size: 25
+        lr: 0.001
         weight_decay: 0.1
         scheduler: 'linear_warmup_cosine_decay'
-        n_warmup_steps: 50
+        n_warmup_steps: 5000
 longdoc:
     chordmixer:
       backbone:

--- a/dataloaders/register.py
+++ b/dataloaders/register.py
@@ -2,7 +2,7 @@ from .genbank import GenbankDataModule
 from .longdoc import LongdocDataModule
 from .adding  import AddingDataModule
 
-from .speech_commands import SpeechCommandsDataModule
+from .speech_commands_pad import SpeechCommandsDataModule
 
 from .lra_listops import ListOpsDataModule
 from .lra_listops_var import ListOpsDataModuleVar

--- a/dataloaders/speech_commands_pad.py
+++ b/dataloaders/speech_commands_pad.py
@@ -1,0 +1,154 @@
+import os
+import math
+import numpy as np
+import torch 
+import torch.nn as nn
+import logging
+from torch.utils.data import DataLoader
+from torchtext.data.utils import get_tokenizer
+from torchtext.vocab import build_vocab_from_iterator
+from datasets import load_dataset, DatasetDict
+from pathlib import Path
+import pytorch_lightning as pl
+from collections import Counter
+from .utils.collators import collate_batch
+
+
+class SpeechCommandsDataModule(pl.LightningDataModule):
+    def __init__(
+        self,
+        data_dir,
+        taskname,
+        num_workers,
+        batch_size,
+        **kwargs,
+    ):
+        super().__init__()
+        self.data_dir = Path(data_dir)
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+
+        self.cache_dir = self.get_cache_dir()
+
+    def prepare_data(self):
+        self.process_dataset()
+
+    def setup(self, stage=None):
+        if stage == "test" and hasattr(self, "dataset_test"):
+            return
+        dataset = self.process_dataset()
+
+        dataset.set_format(type="torch", columns=["sequence", "label", "len"])
+
+        self.train_dataset, self.test_dataset = (
+            dataset["train"],
+            dataset["test"],
+        )
+        self.collate_fn = collate_batch
+
+    def process_dataset(self):
+        if self.cache_dir is not None:
+            return self._load_from_cache()
+        
+        dataset = load_dataset('speech_commands','v0.01')
+        
+        dataset = dataset.filter(lambda example: 1 <= example['label'] <= 3)
+
+        def change_labels(example):
+            if example['label'] == 3:
+                example['label'] = 0
+            return example
+
+        # Apply the function to the 'train' and 'test' splits
+        dataset['train'] = dataset['train'].map(change_labels)
+        dataset['test'] = dataset['test'].map(change_labels)
+        dataset['validation'] = dataset['validation'].map(change_labels)
+
+        label_counter = Counter(dataset['train']['label'])
+
+        # Print the count of instances for each label
+        for label, count in label_counter.items():
+            print(f'Label {label}: {count} instances')
+
+        def quantize(example):
+            min_val, max_val = -1.0, 1.0
+            num_bits = 8
+            sequence = []
+            for sample in example["audio"]["array"]:
+              try:
+                sample = float(sample)
+                sample_normalized = (sample - min_val) / (max_val - min_val)
+                sample_quantized = int(sample_normalized * (2**num_bits - 1))
+                sequence.append(sample_quantized)
+              except:
+                print(sample)
+            example["sequence"] = sequence
+            example["len"] = len(sequence)
+            return example
+        
+        dataset = dataset.map(
+            quantize,
+            remove_columns=["audio"],
+            keep_in_memory=True,
+            load_from_cache_file=False,
+            num_proc=self.num_workers,
+        )
+        
+        self._save_to_cache(dataset)
+        return dataset
+
+    def _save_to_cache(self, dataset):
+        cache_dir = self.data_dir / self._cache_dir_name
+        os.makedirs(str(cache_dir), exist_ok=True)
+        logger = logging.getLogger(__name__)
+        logger.info(f"Saving to cache at {str(cache_dir)}")
+        dataset.save_to_disk(str(cache_dir))
+
+    def _load_from_cache(self):
+        assert self.cache_dir.is_dir()
+        logger = logging.getLogger(__name__)
+        logger.info(f"Load from cache at {str(self.cache_dir)}")
+        dataset = DatasetDict.load_from_disk(str(self.cache_dir))
+        return dataset
+
+    @property
+    def _cache_dir_name(self):
+        return f"speech_commands"
+
+    def get_cache_dir(self):
+        cache_dir = self.data_dir / self._cache_dir_name
+        if cache_dir.is_dir():
+            return cache_dir
+        else:
+            return None
+
+    def train_dataloader(self):
+        train_dataloader = DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            drop_last=True,
+            collate_fn=self.collate_fn,
+        )
+        return train_dataloader
+
+    def val_dataloader(self):
+        val_dataloader = DataLoader(
+            self.test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            collate_fn=self.collate_fn,
+        )
+        return val_dataloader
+
+    def test_dataloader(self):
+        test_dataloader = DataLoader(
+            self.test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            collate_fn=self.collate_fn,
+        )
+        return test_dataloader


### PR DESCRIPTION
Hi, Tyler. Great job! I have managed to improve the test accuracy from 77% to 94.7%
Here are some suggestions:
1. Use equal lengths mode (set diff_len parameter in CH to False) when possible. SpeechCommand data does not have extreme length variability, so the winning in time and accuracy is inferior. There is plenty of advantages when using this mode. It allows using normalizations, leverages multi-gpu training, and speed/memory improvements. All of these are critical for this task, where sequences are almost the same lengths.
2. I observed that increasing LR, n_epochs, batch_size, and the number of warmup steps improves training. So I made a small hyperparameter search that helped to get an additional 2% accuracy. You can further improve it.
3. The performance looks competitive compared to several other models for sequences like [S4](https://arxiv.org/abs/2111.00396) or [CKConv](https://arxiv.org/abs/2102.02611). 

Here is a [small report](https://api.wandb.ai/links/deepntnu/zirgi3n2)